### PR TITLE
Change how to check if fakeroot-tcp is installed

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -16,7 +16,7 @@ yay -Syyuu --noconfirm
 
 echo "Cloning Omakub..."
 rm -rf ~/.local/share/omakub
-git clone https://github.com/akitaonrails/omakub.git ~/.local/share/omakub >/dev/null
+git clone "${OMAKUB_REPO:-https://github.com/akitaonrails/omakub.git}" ~/.local/share/omakub >/dev/null
 if [[ $OMAKUB_REF != "master" ]]; then
   cd ~/.local/share/omakub
   git fetch origin "${OMAKUB_REF:-stable}" && git checkout "${OMAKUB_REF:-stable}"

--- a/install/terminal/app-lazydocker.sh
+++ b/install/terminal/app-lazydocker.sh
@@ -1,6 +1,6 @@
 # Arch under WSL2 already comes with fakeroot-tcp
-if ![ pacman -Q fakeroot-tcp ] &>/dev/null; then
-  sudo pacman -S --needed fakeroot
+if ! $(pacman -Qi fakeroot-tcp &>/dev/null); then
+  sudo pacman -S --needed fakeroot --noconfirm
 fi
 
 yay -S --needed lazydocker-bin --noconfirm


### PR DESCRIPTION
The previous check if `fakeroot-tcp` is installed was always returning true. I'm changing how this is checked in order to check over the result of the query.

I also took the liberty of changing the boot script to check for a `OMAKUB_REPO` environment variable in order to use a specific repository and not yours. I still kept your repository as a fallback for this. I believe this approach will make it easier to others to test and contribute with prs.

This was the error I was getting:

![Screenshot from 2024-11-01 12-47-33](https://github.com/user-attachments/assets/5b6ba7b7-a0e7-4c0f-85aa-d0f61ab1f893)
