### PR TITLE
Fixing installation scripts for Arch-based distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ There is an Arch version for WSL2 on Windows, called [ArchWSL](https://github.co
 
 From a Terminal run:
 
+```sh
     wget -qO- https://raw.githubusercontent.com/akitaonrails/omakub-mj/stable/boot.sh | bash
+```
 
 And follow the instructions on screen. 
 

--- a/install/check-version.sh
+++ b/install/check-version.sh
@@ -8,10 +8,10 @@ fi
 
 . /etc/os-release
 
-if [ "$ID" != "manjaro" ]; then
+if [[ "$ID" != "arch" && "$ID_LIKE" != "arch" ]]; then
   echo "$(tput setaf 1)Error: OS requirement not met"
   echo "You are currently running: $ID"
-  echo "OS required: Manjaro GNOME 24 or higher"
+  echo "OS required: any Arch-based distribution (e.g. Manjaro, Arch, EndeavourOS)"
   echo "Installation stopped."
   exit 1
 fi

--- a/install/desktop/set-alacritty-default.sh
+++ b/install/desktop/set-alacritty-default.sh
@@ -4,7 +4,7 @@
 sudo ln -sf /usr/bin/alacritty /usr/bin/x-terminal-emulato
 
 # Adding alacritty to nautilus contextual menu requires the python wrapper for the libraries
-sudo apt install -y python3-nautilus
+yay -S python-nautilus --noconfirm
 mkdir -p ~/.local/share/nautilus-python/extensions/
 
 cat >~/.local/share/nautilus-python/extensions/open-alacritty.py <<TECHNICALLYNOTACONFIGSOHEREDOCCEDITIS


### PR DESCRIPTION
Commits added:

- :books:  docs(readme): Added code block in code for installation
- :bug:  fix(install/desktop/set-alacritty-default): Converted installation of Debian based for Arch
- :wrench:  chore(install/check-version): allow execution on Arch-based distributions